### PR TITLE
Add basic documentation for authentication

### DIFF
--- a/source/authentication.html.md.erb
+++ b/source/authentication.html.md.erb
@@ -1,0 +1,22 @@
+---
+title: Authentication
+weight: 2
+---
+
+# Authentication
+
+API consumers are authenticated on a service to service level using:
+
+- [mutual TLS](https://www.cloudflare.com/en-gb/learning/access-management/what-is-mutual-tls/) to ensure trust on both
+  the server and client side
+- API keys to track and manage usage of the client
+
+## Connecting using mutual TLS
+
+Using two-way authentication allows HMPPS to additionally verify the identity of a consumer before securely providing
+any data. This means a certificate must be presented as part of make a request.
+
+## Sending an API key
+
+To provide an API key, add an HTTP header called `x-api-key` with the value of the API key to the API request, ensuring
+it's not encoded in Base 64. Without an API key, a `403 Forbidden` HTTP response is returned.

--- a/source/authentication.html.md.erb
+++ b/source/authentication.html.md.erb
@@ -14,7 +14,7 @@ API consumers are authenticated on a service to service level using:
 ## Connecting using mutual TLS
 
 Using two-way authentication allows HMPPS to additionally verify the identity of a consumer before securely providing
-any data. This means a certificate must be presented as part of make a request.
+any data. This means a certificate must be presented as part of making a request.
 
 ## Sending an API key
 

--- a/source/documentation/api/index.html.md.erb
+++ b/source/documentation/api/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-weight: 2
+weight: 3
 ---
 
 api>


### PR DESCRIPTION
## Changes proposed in this PR

- Add a page called `Authentication` which outlines _what_ authentication we use. Worth mentioning this was a bit challenging as we aren't clear on "how" at the moment. As a result, there aren't clear steps of how to do things like "how are client certificates and API keys issued".