### PR TITLE
Add context and container diagrams to API docs

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,4 +7,21 @@ weight: 1
 
 # About
 
-This site provides technical documentation for the HMPPS Integration API.
+## Diagrams
+
+The [C4 model](https://c4model.com/) is used for visualising the technical architecture of the service.
+
+### Context diagram
+
+The [context diagram](https://c4model.com/#SystemContextDiagram) provides a high-level overview of the current systems
+that make up HMPPS Integration API as well as those that are yet to be implemented.
+
+[![Context diagram](https://raw.githubusercontent.com/ministryofjustice/hmpps-integration-api/main/docs/diagrams/context.svg)](https://raw.githubusercontent.com/ministryofjustice/hmpps-integration-api/main/docs/diagrams/context.svg)
+
+### Container diagram
+
+The [container diagram](https://c4model.com/#ContainerDiagram) provides a more in-depth view of the different upstreams
+APIs that are used to retrieve data from the HMPPS systems such as
+the [Prison API](https://api-dev.prison.service.justice.gov.uk/swagger-ui/index.html) for NOMIS.
+
+[![Container diagram](https://raw.githubusercontent.com/ministryofjustice/hmpps-integration-api/main/docs/diagrams/container.svg)](https://raw.githubusercontent.com/ministryofjustice/hmpps-integration-api/main/docs/diagrams/container.svg)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -3,9 +3,11 @@ title: About
 weight: 1
 ---
 
-<!-- Entry point to the site -->
-
 # About
+
+HMPPS Integration API is a RESTFul API that provides a single point of entry for organisations to access data about a
+person within the prison and probation services of Ministry of Justice (MOJ) such as the National Offender Management
+Information System (NOMIS). It uses a Police National Computer identifier (PNC ID) for a person.
 
 ## Diagrams
 


### PR DESCRIPTION
- Update our `About` section with a one-line overview of the API.
- Add context and container diagrams to our `About` section within a new `Diagrams` subsection. I've purposely not included any other diagrams as I don't think they're relevant for API consumers.

![image](https://user-images.githubusercontent.com/42817036/225683938-67a22d96-fe6e-452e-8c2c-ae091889569f.png)
