### PR TITLE
Add alt for example person image in task-based guidance

### DIFF
--- a/source/get-an-image-of-a-person-without-their-pnc-id.html.md.erb
+++ b/source/get-an-image-of-a-person-without-their-pnc-id.html.md.erb
@@ -95,6 +95,6 @@ curl -H "x-api-key: some-client-api-key" \
 
 This will return the image in JPEG format.
 
-<img src="images/example-person-image.jpg" style="border-style: solid; border-color: grey;">
+<img src="images/example-person-image.jpg" style="border-style: solid; border-color: grey;" alt="an example of a person image">
 
 See [getting an image API endpoint](/documentation/api/#images-id) for more details.


### PR DESCRIPTION
This should fix: https://github.com/ministryofjustice/hmpps-integration-api-docs/actions/runs/4562850678/jobs/8050587995.

>At ./docs/get-an-image-of-a-person-without-their-pnc-id.html:235:
>     image images/example-person-image.jpg does not have an alt attribute