### PR TITLE
Added review_by and other required fields for Daniel the Manual Spaniel

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,3 @@ Changes pushed or merged into to `main` are automatically published to GitHub Pa
 Should you need to review the content of our documentation, ensure that the `review_in` field is updated as part of the pull request. This should be formatted `yyyy-mm-dd`.
 
 A Ministry of Justice tool named [Tech Docs Monitor _also known as_ Daniel the Manual Spaniel](https://github.com/ministryofjustice/tech-docs-monitor) will send a notification to the slack channel specified in the `owner_slack` property when a document is due for review.
-

--- a/README.md
+++ b/README.md
@@ -62,3 +62,10 @@ Aspects of the documentation site such as the header and sidebar can be configur
 ## Publishing
 
 Changes pushed or merged into to `main` are automatically published to GitHub Pages and viewable at https://ministryofjustice.github.io/hmpps-integration-api-docs.
+
+### Reviewing
+
+Should you need to review the content of our documentation, ensure that the `review_in` field is updated as part of the pull request. This should be formatted `yyyy-mm-dd`.
+
+A Ministry of Justice tool named [Tech Docs Monitor _also known as_ Daniel the Manual Spaniel](https://github.com/ministryofjustice/tech-docs-monitor) will send a notification to the slack channel specified in the `owner_slack` property when a document is due for review.
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ Changes pushed or merged into to `main` are automatically published to GitHub Pa
 
 ## Reviewing
 
-Should you need to review the content of our documentation, ensure that the `review_in` field is updated as part of the pull request. This should be formatted `yyyy-mm-dd`.
+Should you need to review the content of our documentation, ensure that the `review_in` field is updated as part of the front matter of the markdown page. This should be formatted `yyyy-mm-dd`.
 
-A Ministry of Justice tool named [Tech Docs Monitor _also known as_ Daniel the Manual Spaniel](https://github.com/ministryofjustice/tech-docs-monitor) will send a notification to the slack channel specified in the `owner_slack` property when a document is due for review.
+A Ministry of Justice tool named [Tech Docs Monitor _also known as_ Daniel the Manual Spaniel](https://github.com/ministryofjustice/tech-docs-monitor) will send a notification to the Slack channel specified in the `owner_slack` property when a document is due for review.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Aspects of the documentation site such as the header and sidebar can be configur
 
 Changes pushed or merged into to `main` are automatically published to GitHub Pages and viewable at https://ministryofjustice.github.io/hmpps-integration-api-docs.
 
-### Reviewing
+## Reviewing
 
 Should you need to review the content of our documentation, ensure that the `review_in` field is updated as part of the pull request. This should be formatted `yyyy-mm-dd`.
 

--- a/source/api-changes-and-versioning.html.md.erb
+++ b/source/api-changes-and-versioning.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: API Changes and Versioning
 weight: 4
+owner_slack: "#hmpps-integration-api"
+last_reviewed_on: 2023-04-03
+review_by: 2023-07-04
 ---
 
 # API changes and versioning

--- a/source/authentication.html.md.erb
+++ b/source/authentication.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Authentication
 weight: 3
+owner_slack: "#hmpps-integration-api"
+last_reviewed_on: 2023-04-03
+review_by: 2023-04-04
 ---
 
 # Authentication

--- a/source/documentation/adr/index.html.md.erb
+++ b/source/documentation/adr/index.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Architecture Decision Records
 weight: 9
+owner_slack: "#hmpps-integration-api"
+last_reviewed_on: 2023-04-03
+review_by: 2023-04-04
 ---
 
 # Architecture Decision Records

--- a/source/documentation/api/index.html.md.erb
+++ b/source/documentation/api/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Open API Specification
-weight: 3
+weight: 5
 owner_slack: "#hmpps-integration-api"
 last_reviewed_on: 2023-04-03
 review_by: 2023-07-04

--- a/source/documentation/api/index.html.md.erb
+++ b/source/documentation/api/index.html.md.erb
@@ -1,5 +1,9 @@
 ---
-weight: 5
+title: Open API Specification
+weight: 3
+owner_slack: "#hmpps-integration-api"
+last_reviewed_on: 2023-04-03
+review_by: 2023-07-04
 ---
 
 api>

--- a/source/documentation/get-started/index.html.md.erb
+++ b/source/documentation/get-started/index.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Get started
 weight: 2
+owner_slack: "#hmpps-integration-api"
+last_reviewed_on: 2023-04-03
+review_by: 2023-07-04
 ---
 # Get started
 

--- a/source/get-an-image-of-a-person-without-their-pnc-id.html.md.erb
+++ b/source/get-an-image-of-a-person-without-their-pnc-id.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Get an image of a person without their PNC ID
 weight: 4
+owner_slack: "#hmpps-integration-api"
+last_reviewed_on: 2023-04-03
+review_by: 2023-07-04
 ---
 
 # Get an image of a person without their PNC ID

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -30,4 +30,3 @@ APIs that are used to retrieve data from the HMPPS systems such as
 the [Prison API](https://api-dev.prison.service.justice.gov.uk/swagger-ui/index.html) for NOMIS.
 
 [![Container diagram](https://raw.githubusercontent.com/ministryofjustice/hmpps-integration-api/main/docs/diagrams/container.svg)](https://raw.githubusercontent.com/ministryofjustice/hmpps-integration-api/main/docs/diagrams/container.svg)
-

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: About
 weight: 1
+owner_slack: "#hmpps-integration-api"
+last_reviewed_on: 2023-04-03
+review_by: 2023-07-04
 ---
 
 # About

--- a/source/links.html.md.erb
+++ b/source/links.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Useful links
 weight: 10
+owner_slack: "#hmpps-integration-api"
+last_reviewed_on: 2023-04-03
+review_by: 2023-07-04
 ---
 
 # Useful links


### PR DESCRIPTION
This is so that we can implement Daniel the Manual Spaniel. So there are a number of fields added to each page at the top. This is in support of https://dsdmoj.atlassian.net/jira/software/c/projects/HIA/boards/1056?modal=detail&selectedIssue=HIA-253.

> ADR and Authentication have their `review_by` dates intentionally set to yesterday so I can test it's working.