### PR TITLE
Fix link to endpoints

### DIFF
--- a/source/documentation/get-started/index.html.md.erb
+++ b/source/documentation/get-started/index.html.md.erb
@@ -25,4 +25,4 @@ For information on how to use these credentials, please see the [Authentication]
 
 ## Explore available endpoints
 
-You should now have access to all our [endpoints](/documentation/api/).
+You should now have access to all our [endpoints](/hmpps-integration-api-docs/documentation/api).


### PR DESCRIPTION
Getting started currently points to a page that doesn't exist.