### PR TITLE
Update URLs in curl examples for new environments

### DIFF
--- a/source/get-an-image-of-a-person-without-their-pnc-id.html.md.erb
+++ b/source/get-an-image-of-a-person-without-their-pnc-id.html.md.erb
@@ -17,7 +17,7 @@ An example curl command to search on the name "John Smith" looks like:
 
 ```bash
 curl -H "x-api-key: some-client-api-key" \
-  https://development.integration-api.hmpps.service.justice.gov.uk/v1/persons?first_name=John&last_name=Smith \
+  https://dev.integration-api.hmpps.service.justice.gov.uk/v1/persons?first_name=John&last_name=Smith \
   --cert client.pem \
   --key client.key
 ```
@@ -55,7 +55,7 @@ An example curl command that returns a list of images associated with the PNC ID
 
 ```bash
 curl -H "x-api-key: some-client-api-key" \
-  https://development.integration-api.hmpps.service.justice.gov.uk/v1/persons/2008%2F0545166T/images \
+  https://dev.integration-api.hmpps.service.justice.gov.uk/v1/persons/2008%2F0545166T/images \
   --cert client.pem \
   --key client.key
 ```
@@ -91,7 +91,7 @@ An example curl command that returns an image associated with the ID `2461788` l
 
 ```bash
 curl -H "x-api-key: some-client-api-key" \
-  https://development.integration-api.hmpps.service.justice.gov.uk/v1/images/2461788 \
+  https://dev.integration-api.hmpps.service.justice.gov.uk/v1/images/2461788 \
   --cert client.pem \
   --key client.key
 ```


### PR DESCRIPTION
Our examples currently point to old non-existing URLs, update this to reflect the new names.