### PR TITLE
Remove links to ADRs that are not relevant for an external consumer

### DIFF
--- a/source/documentation/adr/index.html.md.erb
+++ b/source/documentation/adr/index.html.md.erb
@@ -10,10 +10,6 @@ review_in: 2 months
 
 | Status                                             | Adr No. | Title                                     |
 |----------------------------------------------------|---------|-------------------------------------------|
-| <strong class="govuk-tag--green">ACCEPTED</strong> | 0001    | [Use CircleCI](https://github.com/ministryofjustice/hmpps-integration-api/blob/main/docs/adr/0001-use-circleci.md) |
-| <strong class="govuk-tag--green">ACCEPTED</strong> | 0002    | [Use PlantUML to create diagrams](https://github.com/ministryofjustice/hmpps-integration-api/blob/main/docs/adr/0002-plantuml-diagrams-as-code.md) |
-| <strong class="govuk-tag--green">ACCEPTED</strong> | 0003    | [Manually manage OpenAPI specification file](https://github.com/ministryofjustice/hmpps-integration-api/blob/main/docs/adr/0003-manually-manage-openapi-file.md) |
 | <strong class="govuk-tag--green">ACCEPTED</strong> | 0004    | [Always return a JSON object for JSON responses](https://github.com/ministryofjustice/hmpps-integration-api/blob/main/docs/adr/0004-always-return-a-json-object-for-json-responses.md) |
-| <strong class="govuk-tag--green">ACCEPTED</strong> | 0005    | [Use Data Transfer Object Pattern](https://github.com/ministryofjustice/hmpps-integration-api/blob/main/docs/adr/0005-use-dto-pattern.md) |
 | <strong class="govuk-tag--green">ACCEPTED</strong> | 0006    | [URL-encode path parameters that contain a forward slash](https://github.com/ministryofjustice/hmpps-integration-api/blob/main/docs/adr/0006-url-encode-path-parameters.md) |
 | <strong class="govuk-tag--green">ACCEPTED</strong> | 0007    | [Version through URL path](https://github.com/ministryofjustice/hmpps-integration-api/blob/main/docs/adr/0007-version-through-url-path.md) |


### PR DESCRIPTION
Only include links to ADRs that are relevant for an external consumer. For example, what service we use for our CI/CD pipeline isn't considered to be relevant for someone using our API.